### PR TITLE
support torch inference mode for pipelines

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -153,7 +153,7 @@ services:
       - PIPELINE_SERVER_SERVICE_TYPE=pipeline
       - PIPELINE_SERVER_SERVICE_NAME=pipeline
       - PIPELINE_SERVER_SETTINGS_GADGET_DATA_BROKER_SUB_TOPICS=sensor/profiler
-      - PIPELINE_SERVER_SETTINGS_MODELS_ROOT=/home/gadget/pipeline/models
+      - PIPELINE_SERVER_SETTINGS_MODELS_ROOT=/home/gadget/pipeline/trt-engines
       - PIPELINE_SERVER_SETTINGS_PIPELINE_PATH=/home/gadget/pipeline
       - PIPELINE_SERVER_SETTINGS_PIPELINE_CLASS=pipeline_class.ModelPipeline
       - PIPELINE_SERVER_SETTINGS_PIPELINE_DEFINITION_JSON=pipeline_def.json

--- a/pipeline/pipeline.dockerfile
+++ b/pipeline/pipeline.dockerfile
@@ -9,6 +9,7 @@ WORKDIR /home/gadget
 # install dependecies
 COPY ./requirements.txt .
 RUN pip3 install -r requirements.txt
+RUN pip install torch
 
 
 RUN python3 -m pip install gadget_pipeline_server==$PACKAGE_VER --extra-index-url $PYPI_SERVER

--- a/pipeline/pipeline.dockerfile
+++ b/pipeline/pipeline.dockerfile
@@ -4,7 +4,7 @@ FROM  python:3.8.12-buster
 ARG PACKAGE_VER
 ARG PYPI_SERVER
 
-WORKDIR /home/gadget/workspace
+WORKDIR /home/gadget
 
 # install dependecies
 COPY ./requirements.txt .

--- a/pipeline/pipeline_class.py
+++ b/pipeline/pipeline_class.py
@@ -11,6 +11,8 @@ this pipeline class, needs to have the following methods:
 
 import logging
 from pipeline_base import PipelineBase as Base
+import torch
+
 
 class ModelPipeline(Base):
 
@@ -41,6 +43,7 @@ class ModelPipeline(Base):
         pass
 
 
+    @torch.inference_mode()
     @Base.track_exception(logger)
     def predict(self, configs: dict, inputs: dict) -> dict:
         """predict on the inputs


### PR DESCRIPTION
1. In pipeline/predict, we should not calculate gradients. So, we should use torch.inference_mode. 
2. fix some discrepancies between pipeline and docker-compose.yaml